### PR TITLE
プロジェクトファイルの修正

### DIFF
--- a/__.swift.xcodeproj/project.pbxproj
+++ b/__.swift.xcodeproj/project.pbxproj
@@ -437,7 +437,6 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SYMROOT = "";
 			};
 			name = Debug;
 		};
@@ -472,7 +471,6 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				METAL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
-				SYMROOT = "";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -486,7 +484,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MACH_O_TYPE = mh_dylib;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SYMROOT = /Users/tatyusa/Documents/workspace/__.swift;
 			};
 			name = Debug;
 		};
@@ -499,7 +496,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MACH_O_TYPE = mh_dylib;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SYMROOT = /Users/tatyusa/Documents/workspace/__.swift;
 			};
 			name = Release;
 		};
@@ -518,7 +514,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				METAL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SYMROOT = /Users/tatyusa/Documents/workspace/__.swift;
 			};
 			name = Debug;
 		};
@@ -533,7 +528,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				METAL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SYMROOT = /Users/tatyusa/Documents/workspace/__.swift;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
プロジェクトファイル内で Build Products Path (SYMROOT) が絶対パスで指定されていて,
他の環境でデフォルトの設定のままではビルドできない問題を修正しました.
確認お願いします.
